### PR TITLE
Support passing config directly to puppeteer

### DIFF
--- a/src/mink.js
+++ b/src/mink.js
@@ -38,10 +38,14 @@ Mink.prototype.hook = function (cucumber) {
   });
 };
 Mink.prototype.setup = async function () {
-  this.browser = await puppeteer.launch({
+  puppeteer_config = {
     headless: this.config.headless && !this.config.devtools,
     devtools: this.config.devtools,
-  });
+  }
+  if ('puppeteer' in this.config) {
+    Object.assign(puppeteer_config, this.config.puppeteer);
+  }
+  this.browser = await puppeteer.launch(puppeteer_config);
   this.page = await this.browser.newPage();
   return this.page.setViewport(this.config.viewport);
 };

--- a/src/mink.js
+++ b/src/mink.js
@@ -38,7 +38,7 @@ Mink.prototype.hook = function (cucumber) {
   });
 };
 Mink.prototype.setup = async function () {
-  puppeteer_config = {
+  const puppeteer_config = {
     headless: this.config.headless && !this.config.devtools,
     devtools: this.config.devtools,
   }


### PR DESCRIPTION
Github Actions seems to be dropping older versions of Ubuntu, and that is causing problems with the usage of this library. When we try using `ubuntu-22.04` or `ubuntu-latest` in Github Actions we get messages like this:

```
VError: a BeforeAll hook errored, process exiting: node_modules/cucumber-mink/src/mink.js:34: Failed to launch the browser process!
[0218/173508.678356:FATAL:zygote_host_impl_linux.cc(116)] No usable sandbox! Update your kernel or see https://chromium.googlesource.com/chromium/src/+/master/docs/linux/suid_sandbox_development.md for more information on developing with the SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
```

This PR allows for passing some config to puppeteer, which gets around the problem by passing in `args: ['--no-sandbox', '--disable-setuid-sandbox']` to puppeteer, like in this example:

```
const cucumber = require('@cucumber/cucumber');
const mink = require('cucumber-mink');

const driver = new mink.Mink({
  baseUrl: 'http://localhost:4000',
  viewport: {
    width: 1366,
    height: 768,
  },
  headless: true,
  devtools: false,
  puppeteer: {
    args: ['--no-sandbox', '--disable-setuid-sandbox'],
  },
});

driver.hook(cucumber);
```

In my testing this lets us continue to use this library with the latest Ubuntu.